### PR TITLE
2. add server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
 
 go:
-  - 1.7.x
   - 1.8.x

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
-test:
+test: deps
 	go test -v ./...
+
+deps: 
+	go get "github.com/julienschmidt/httprouter"

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/riccardomc/teleq/stack"
+)
+
+//StackServer
+type StackServer struct {
+	Stack  *stack.Stack
+	Router *httprouter.Router
+}
+
+func size(server *StackServer) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprintln(w, server.Stack.Size())
+	}
+}
+
+func peek(server *StackServer) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, server.Stack.Peek())
+	}
+}
+
+func push(server *StackServer) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, rp httprouter.Params) {
+		value, err := url.PathUnescape(rp.ByName("value"))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, err)
+			return
+		}
+		server.Stack.Push(value)
+		fmt.Fprintln(w, value)
+	}
+}
+
+func pop(server *StackServer) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprintln(w, server.Stack.Pop())
+	}
+}
+
+//NewStackServer gives you a new server, yo
+func NewStackServer() *StackServer {
+	server := StackServer{stack.New(), httprouter.New()}
+	server.Router.GET("/peek", peek(&server))
+	server.Router.POST("/push/:value", push(&server))
+	server.Router.GET("/pop", pop(&server))
+	server.Router.GET("/size", size(&server))
+	return &server
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,332 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSize(t *testing.T) {
+	targetServer := NewStackServer()
+	request, err := http.NewRequest("GET", "/size", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Size on Stack with no elements", func(t *testing.T) {
+		expectedStatus := http.StatusOK
+		expectedContent := "0"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+	})
+
+	t.Run("Size on Stack with one element", func(t *testing.T) {
+		targetServer.Stack.Push("one element")
+		expectedStatus := http.StatusOK
+		expectedContent := "1"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+	})
+
+	t.Run("Size on Stack with multiple elements", func(t *testing.T) {
+		targetServer.Stack.Push("another element")
+		targetServer.Stack.Push("yet another element")
+		expectedStatus := http.StatusOK
+		expectedContent := "3"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+	})
+}
+
+func TestPeek(t *testing.T) {
+	targetServer := NewStackServer()
+	request, err := http.NewRequest("GET", "/peek", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Peek on Stack with no elements", func(t *testing.T) {
+		expectedStatus := http.StatusOK
+		expectedContent := "<nil>"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+	})
+
+	t.Run("Peek on Stack with one element", func(t *testing.T) {
+		targetServer.Stack.Push("one element")
+		expectedStatus := http.StatusOK
+		expectedContent := "one element"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+	})
+
+	t.Run("Peek on Stack with multiple elements", func(t *testing.T) {
+		targetServer.Stack.Push("another element")
+		expectedStatus := http.StatusOK
+		expectedContent := "another element"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+	})
+}
+
+func TestPush(t *testing.T) {
+	targetServer := NewStackServer()
+
+	t.Run("Push on Stack with no elements", func(t *testing.T) {
+		request, _ := http.NewRequest("POST", "/push/one element", nil)
+		expectedStatus := http.StatusOK
+		expectedContent := "one element"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+		actualStackContent := targetServer.Stack.Peek()
+		if actualStackContent != expectedContent {
+			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
+		}
+		actualStackSize := targetServer.Stack.Size()
+		if actualStackSize != 1 {
+			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
+		}
+	})
+
+	t.Run("Push on Stack with one element", func(t *testing.T) {
+		request, _ := http.NewRequest("POST", "/push/another element", nil)
+		expectedStatus := http.StatusOK
+		expectedContent := "another element"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+		actualStackContent := targetServer.Stack.Peek()
+		if actualStackContent != expectedContent {
+			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
+		}
+		actualStackSize := targetServer.Stack.Size()
+		if actualStackSize != 2 {
+			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
+		}
+	})
+
+	t.Run("Push on Stack with multiple elements", func(t *testing.T) {
+		request, _ := http.NewRequest("POST", "/push/yet another element", nil)
+		expectedStatus := http.StatusOK
+		expectedContent := "yet another element"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+		actualStackContent := targetServer.Stack.Peek()
+		if actualStackContent != expectedContent {
+			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
+		}
+		actualStackSize := targetServer.Stack.Size()
+		if actualStackSize != 3 {
+			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
+		}
+	})
+}
+
+func TestPop(t *testing.T) {
+	targetServer := NewStackServer()
+	request, err := http.NewRequest("GET", "/pop", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Pop on Stack with no elements", func(t *testing.T) {
+		expectedStatus := http.StatusOK
+		expectedContent := "<nil>"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+	})
+
+	t.Run("Pop on Stack with one element", func(t *testing.T) {
+		targetServer.Stack.Push("one element")
+		expectedStatus := http.StatusOK
+		expectedContent := "one element"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+		actualStackContent := targetServer.Stack.Peek()
+		if actualStackContent != nil {
+			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
+		}
+		actualStackSize := targetServer.Stack.Size()
+		if actualStackSize != 0 {
+			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
+		}
+	})
+
+	t.Run("Pop on Stack with multiple elements", func(t *testing.T) {
+		targetServer.Stack.Push("one element")
+		targetServer.Stack.Push("another element")
+		expectedStatus := http.StatusOK
+		expectedContent := "another element"
+
+		response, err := call(targetServer, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actualStatus := response.Code
+		if actualStatus != expectedStatus {
+			t.Errorf("Unexpected status: '%v'", actualStatus)
+		}
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: '%v'", actualContent)
+		}
+		actualStackContent := targetServer.Stack.Peek()
+		if actualStackContent != "one element" {
+			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
+		}
+		actualStackSize := targetServer.Stack.Size()
+		if actualStackSize != 1 {
+			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
+		}
+	})
+}
+
+func call(targetServer *StackServer, request *http.Request) (*httptest.ResponseRecorder, error) {
+	method := request.Method
+	path := request.URL.String()
+	targetHandle, params, _ := targetServer.Router.Lookup(method, path)
+	if targetHandle == nil {
+		return nil, fmt.Errorf("Cannot find route '%s' '%s'", method, path)
+	}
+
+	handler := http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) { targetHandle(w, r, params) })
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	return recorder, nil
+}


### PR DESCRIPTION
I want to be able to perform the four operations defined on my stack via HTTP requests. I wanted to try out [httprouter](https://github.com/julienschmidt/httprouter) to handle paths and parameters.

To reference my data structure from the handler functions, I use a simple closure that passes a reference to a `StackServer` struct which contains the `Stack`. So creating a StackServer is very easy:
```go
func NewStackServer() *StackServer {
	server := StackServer{stack.New(), httprouter.New()}
	server.Router.GET("/peek", peek(&server))
	server.Router.POST("/push/:value", push(&server))
	server.Router.GET("/pop", pop(&server))
	server.Router.GET("/size", size(&server))
	return &server
}
```
And so is wiring it to an actual HTTP server:
```go
func main() {
	server := server.NewStackServer()
	http.ListenAndServe(":9009", server.Router)
}
```

The testing part is a bit long and boring, maybe I can find a better way to do that, but I didn't want to abstract too much of the test machinery. To simulate each call I used a wrapper function that implements the [http.HandlerFunc](https://golang.org/pkg/net/http/#HandlerFunc) interface and [httptest.ResponseRecorder](https://golang.org/pkg/net/http/httptest/#ResponseRecorder) to inspect the responses.
```go
func call(targetServer *StackServer, request *http.Request) (*httptest.ResponseRecorder, error) {
	method := request.Method
	path := request.URL.String()
	targetHandle, params, _ := targetServer.Router.Lookup(method, path)
	if targetHandle == nil {
		return nil, fmt.Errorf("Cannot find route '%s' '%s'", method, path)
	}

	handler := http.HandlerFunc(
		func(w http.ResponseWriter, r *http.Request) { targetHandle(w, r, params) })
	recorder := httptest.NewRecorder()
	handler.ServeHTTP(recorder, request)

	return recorder, nil
}
```

Notice that this uses the `Router` object in the target `StackServer` to retrieve the handler function. It is also easy to examine the actual content of the `Stack` through the `StackServer` struct after each call.
Another interesting approach (and probably simpler) available in golang [httptest](https://golang.org/pkg/net/http/httptest/) would be to perform end to end testing by spinning up an entire server.

The data format used is still plain strings.