### PR TITLE
3. serialize/deserialize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,9 @@ test: deps
 
 deps: 
 	go get "github.com/julienschmidt/httprouter"
+
+teleq: server/server.go
+	go build
+
+run: teleq
+	./teleq

--- a/main.go
+++ b/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/riccardomc/teleq/server"
+)
+
+func main() {
+	server := server.NewStackServer()
+	http.ListenAndServe(":9009", server.Router)
+}

--- a/models/response.go
+++ b/models/response.go
@@ -1,0 +1,7 @@
+package models
+
+//Response is used in server replies
+type Response struct {
+	Operation string
+	Data      interface{}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,8 @@ func size(server *StackServer) httprouter.Handle {
 func peek(server *StackServer) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, server.Stack.Peek())
+		response := models.Response{"peek", server.Stack.Peek()}
+		json.NewEncoder(w).Encode(response)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -42,13 +42,16 @@ func push(server *StackServer) httprouter.Handle {
 			return
 		}
 		server.Stack.Push(value)
-		fmt.Fprintln(w, value)
+		response := models.Response{"push", value}
+		json.NewEncoder(w).Encode(response)
 	}
 }
 
 func pop(server *StackServer) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		fmt.Fprintln(w, server.Stack.Pop())
+		w.Header().Set("Content-Type", "application/json")
+		response := models.Response{"pop", server.Stack.Pop()}
+		json.NewEncoder(w).Encode(response)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,15 +1,17 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/riccardomc/teleq/models"
 	"github.com/riccardomc/teleq/stack"
 )
 
-//StackServer
+//StackServer serves a stack through an httprouter
 type StackServer struct {
 	Stack  *stack.Stack
 	Router *httprouter.Router
@@ -17,7 +19,9 @@ type StackServer struct {
 
 func size(server *StackServer) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		fmt.Fprintln(w, server.Stack.Size())
+		w.Header().Set("Content-Type", "application/json")
+		response := models.Response{"size", server.Stack.Size()}
+		json.NewEncoder(w).Encode(response)
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -149,7 +149,7 @@ func TestPush(t *testing.T) {
 	t.Run("Push on Stack with no elements", func(t *testing.T) {
 		request, _ := http.NewRequest("POST", "/push/one element", nil)
 		expectedStatus := http.StatusOK
-		expectedContent := "one element"
+		expectedContent := models.Response{"push", "one element"}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -160,24 +160,23 @@ func TestPush(t *testing.T) {
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
-		}
 		actualStackContent := targetServer.Stack.Peek()
-		if actualStackContent != expectedContent {
+		if actualStackContent != expectedContent.Data {
 			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
 		}
 		actualStackSize := targetServer.Stack.Size()
 		if actualStackSize != 1 {
 			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
 		}
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
+		compareContent(actualContent, expectedContent, t)
 	})
 
 	t.Run("Push on Stack with one element", func(t *testing.T) {
 		request, _ := http.NewRequest("POST", "/push/another element", nil)
 		expectedStatus := http.StatusOK
-		expectedContent := "another element"
+		expectedContent := models.Response{"push", "another element"}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -188,24 +187,23 @@ func TestPush(t *testing.T) {
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
-		}
 		actualStackContent := targetServer.Stack.Peek()
-		if actualStackContent != expectedContent {
+		if actualStackContent != expectedContent.Data {
 			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
 		}
 		actualStackSize := targetServer.Stack.Size()
 		if actualStackSize != 2 {
 			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
 		}
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
+		compareContent(actualContent, expectedContent, t)
 	})
 
 	t.Run("Push on Stack with multiple elements", func(t *testing.T) {
 		request, _ := http.NewRequest("POST", "/push/yet another element", nil)
 		expectedStatus := http.StatusOK
-		expectedContent := "yet another element"
+		expectedContent := models.Response{"push", "yet another element"}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -216,18 +214,17 @@ func TestPush(t *testing.T) {
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
-		}
 		actualStackContent := targetServer.Stack.Peek()
-		if actualStackContent != expectedContent {
+		if actualStackContent != expectedContent.Data {
 			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
 		}
 		actualStackSize := targetServer.Stack.Size()
 		if actualStackSize != 3 {
 			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
 		}
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
+		compareContent(actualContent, expectedContent, t)
 	})
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -237,7 +237,7 @@ func TestPop(t *testing.T) {
 
 	t.Run("Pop on Stack with no elements", func(t *testing.T) {
 		expectedStatus := http.StatusOK
-		expectedContent := "<nil>"
+		expectedContent := models.Response{"pop", nil}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -248,16 +248,15 @@ func TestPop(t *testing.T) {
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
-		}
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
+		compareContent(actualContent, expectedContent, t)
 	})
 
 	t.Run("Pop on Stack with one element", func(t *testing.T) {
 		targetServer.Stack.Push("one element")
 		expectedStatus := http.StatusOK
-		expectedContent := "one element"
+		expectedContent := models.Response{"pop", "one element"}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -267,10 +266,6 @@ func TestPop(t *testing.T) {
 		actualStatus := response.Code
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
-		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
 		}
 		actualStackContent := targetServer.Stack.Peek()
 		if actualStackContent != nil {
@@ -280,13 +275,16 @@ func TestPop(t *testing.T) {
 		if actualStackSize != 0 {
 			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
 		}
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
+		compareContent(actualContent, expectedContent, t)
 	})
 
 	t.Run("Pop on Stack with multiple elements", func(t *testing.T) {
 		targetServer.Stack.Push("one element")
 		targetServer.Stack.Push("another element")
 		expectedStatus := http.StatusOK
-		expectedContent := "another element"
+		expectedContent := models.Response{"pop", "another element"}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -297,10 +295,6 @@ func TestPop(t *testing.T) {
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
-		}
 		actualStackContent := targetServer.Stack.Peek()
 		if actualStackContent != "one element" {
 			t.Errorf("Unexpected stack content: '%v'", actualStackContent)
@@ -309,6 +303,9 @@ func TestPop(t *testing.T) {
 		if actualStackSize != 1 {
 			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
 		}
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
+		compareContent(actualContent, expectedContent, t)
 	})
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,7 +20,7 @@ func TestSize(t *testing.T) {
 
 	t.Run("Size on Stack with no elements", func(t *testing.T) {
 		expectedStatus := http.StatusOK
-		expectedContent := models.Response{"size", "0"}
+		expectedContent := `{"Operation":"size","Data":0}`
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -28,25 +28,19 @@ func TestSize(t *testing.T) {
 		}
 
 		actualStatus := response.Code
-		actualContent := models.Response{}
-		decoder := json.NewDecoder(response.Body)
-		decoder.UseNumber()
-		decoder.Decode(&actualContent)
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		if actualContent.Operation != actualContent.Operation {
-			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Operation, expectedContent.Operation)
-		}
-		if actualContent.Data != actualContent.Data {
-			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Data, expectedContent.Data)
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: %s != %s", actualContent, expectedContent)
 		}
 	})
 
 	t.Run("Size on Stack with one element", func(t *testing.T) {
 		targetServer.Stack.Push("one element")
 		expectedStatus := http.StatusOK
-		expectedContent := models.Response{"size", 1}
+		expectedContent := `{"Operation":"size","Data":1}`
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -54,16 +48,12 @@ func TestSize(t *testing.T) {
 		}
 
 		actualStatus := response.Code
-		actualContent := models.Response{}
-		json.NewDecoder(response.Body).Decode(&actualContent)
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		if actualContent.Operation != actualContent.Operation {
-			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Operation, expectedContent.Operation)
-		}
-		if actualContent.Data != actualContent.Data {
-			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Data, expectedContent.Data)
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: %s != %s", actualContent, expectedContent)
 		}
 	})
 
@@ -71,7 +61,7 @@ func TestSize(t *testing.T) {
 		targetServer.Stack.Push("another element")
 		targetServer.Stack.Push("yet another element")
 		expectedStatus := http.StatusOK
-		expectedContent := models.Response{"size", 2}
+		expectedContent := `{"Operation":"size","Data":3}`
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -79,16 +69,12 @@ func TestSize(t *testing.T) {
 		}
 
 		actualStatus := response.Code
-		actualContent := models.Response{}
-		json.NewDecoder(response.Body).Decode(&actualContent)
+		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		if actualContent.Operation != actualContent.Operation {
-			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Operation, expectedContent.Operation)
-		}
-		if actualContent.Data != actualContent.Data {
-			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Data, expectedContent.Data)
+		if actualContent != expectedContent {
+			t.Errorf("Unexpected content: %s != %s", actualContent, expectedContent)
 		}
 	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,11 +1,14 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/riccardomc/teleq/models"
 )
 
 func TestSize(t *testing.T) {
@@ -17,7 +20,7 @@ func TestSize(t *testing.T) {
 
 	t.Run("Size on Stack with no elements", func(t *testing.T) {
 		expectedStatus := http.StatusOK
-		expectedContent := "0"
+		expectedContent := models.Response{"size", "0"}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -25,19 +28,25 @@ func TestSize(t *testing.T) {
 		}
 
 		actualStatus := response.Code
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		actualContent := models.Response{}
+		decoder := json.NewDecoder(response.Body)
+		decoder.UseNumber()
+		decoder.Decode(&actualContent)
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
+		if actualContent.Operation != actualContent.Operation {
+			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Operation, expectedContent.Operation)
+		}
+		if actualContent.Data != actualContent.Data {
+			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Data, expectedContent.Data)
 		}
 	})
 
 	t.Run("Size on Stack with one element", func(t *testing.T) {
 		targetServer.Stack.Push("one element")
 		expectedStatus := http.StatusOK
-		expectedContent := "1"
+		expectedContent := models.Response{"size", 1}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -45,12 +54,16 @@ func TestSize(t *testing.T) {
 		}
 
 		actualStatus := response.Code
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
+		if actualContent.Operation != actualContent.Operation {
+			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Operation, expectedContent.Operation)
+		}
+		if actualContent.Data != actualContent.Data {
+			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Data, expectedContent.Data)
 		}
 	})
 
@@ -58,7 +71,7 @@ func TestSize(t *testing.T) {
 		targetServer.Stack.Push("another element")
 		targetServer.Stack.Push("yet another element")
 		expectedStatus := http.StatusOK
-		expectedContent := "3"
+		expectedContent := models.Response{"size", 2}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -66,12 +79,16 @@ func TestSize(t *testing.T) {
 		}
 
 		actualStatus := response.Code
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
+		if actualContent.Operation != actualContent.Operation {
+			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Operation, expectedContent.Operation)
+		}
+		if actualContent.Data != actualContent.Data {
+			t.Errorf("Unexpected content: '%s' != '%s'", actualContent.Data, expectedContent.Data)
 		}
 	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -102,7 +102,7 @@ func TestPeek(t *testing.T) {
 
 	t.Run("Peek on Stack with no elements", func(t *testing.T) {
 		expectedStatus := http.StatusOK
-		expectedContent := "<nil>"
+		expectedContent := models.Response{"peek", nil}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -110,19 +110,18 @@ func TestPeek(t *testing.T) {
 		}
 
 		actualStatus := response.Code
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
-		}
+		compareContent(actualContent, expectedContent, t)
 	})
 
 	t.Run("Peek on Stack with one element", func(t *testing.T) {
 		targetServer.Stack.Push("one element")
 		expectedStatus := http.StatusOK
-		expectedContent := "one element"
+		expectedContent := models.Response{"peek", "one element"}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -130,19 +129,18 @@ func TestPeek(t *testing.T) {
 		}
 
 		actualStatus := response.Code
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
-		}
+		compareContent(actualContent, expectedContent, t)
 	})
 
 	t.Run("Peek on Stack with multiple elements", func(t *testing.T) {
 		targetServer.Stack.Push("another element")
 		expectedStatus := http.StatusOK
-		expectedContent := "another element"
+		expectedContent := models.Response{"peek", "another element"}
 
 		response, err := call(targetServer, request)
 		if err != nil {
@@ -150,13 +148,12 @@ func TestPeek(t *testing.T) {
 		}
 
 		actualStatus := response.Code
+		actualContent := models.Response{}
+		json.NewDecoder(response.Body).Decode(&actualContent)
 		if actualStatus != expectedStatus {
 			t.Errorf("Unexpected status: '%v'", actualStatus)
 		}
-		actualContent := strings.TrimRight(response.Body.String(), "\n\t ")
-		if actualContent != expectedContent {
-			t.Errorf("Unexpected content: '%v'", actualContent)
-		}
+		compareContent(actualContent, expectedContent, t)
 	})
 }
 
@@ -330,6 +327,15 @@ func TestPop(t *testing.T) {
 			t.Errorf("Unexpected stack size: '%v'", actualStackSize)
 		}
 	})
+}
+
+func compareContent(actual, expected models.Response, t *testing.T) {
+	if actual.Operation != expected.Operation {
+		t.Errorf("Unexpected Operation: '%s' != '%s'", actual.Operation, expected.Operation)
+	}
+	if actual.Data != expected.Data {
+		t.Errorf("Unexpected Data: '%s' != '%s'", actual.Data, expected.Data)
+	}
 }
 
 func call(targetServer *StackServer, request *http.Request) (*httptest.ResponseRecorder, error) {


### PR DESCRIPTION
Initially I thought of serialize/deserialize whole `Frame` structs, but in the end I've decided to introduce a new structure to be used as response:
```golang
type Response struct {
	Operation string
	Data      interface{}
}
```
Changing from string representation to proper JSON is extremely easy in golang:
```golang
w.Header().Set("Content-Type", "application/json")
response := models.Response{"size", server.Stack.Size()}
json.NewEncoder(w).Encode(response)
```
This is all it takes to populate and encode a `Response` struct as a reply to a `/size` call.

There are some details that need to be kept into consideration when deserializing (or decoding), especially when dealing with `interface{}`. More details [here](https://blog.golang.org/json-and-go).

One example is numbers, which are deserialized into `float64` [by default](https://golang.org/pkg/encoding/json/#Unmarshal).

This is what would happen when deserializing a `Response` from a `/size` call:
```golang
Response{"size", 0}
Response{"size", 3.14}
```
Both serialize to `Response{string, float64}`. In my tests, I just compare the string representation.

JSON serialization of structs can be altered with [annotations](https://golang.org/pkg/encoding/json/#Marshal).