### PR TITLE
3. serialize/deserialize

### DIFF
--- a/models/request.go
+++ b/models/request.go
@@ -1,0 +1,6 @@
+package models
+
+//Request represents the request body used in a push operation
+type Request struct {
+	Data interface{}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -147,7 +147,8 @@ func TestPush(t *testing.T) {
 	targetServer := NewStackServer()
 
 	t.Run("Push on Stack with no elements", func(t *testing.T) {
-		request, _ := http.NewRequest("POST", "/push/one element", nil)
+		body := strings.NewReader(`{"Data": "one element"}`)
+		request, _ := http.NewRequest("POST", "/push", body)
 		expectedStatus := http.StatusOK
 		expectedContent := models.Response{"push", "one element"}
 
@@ -174,7 +175,8 @@ func TestPush(t *testing.T) {
 	})
 
 	t.Run("Push on Stack with one element", func(t *testing.T) {
-		request, _ := http.NewRequest("POST", "/push/another element", nil)
+		body := strings.NewReader(`{"Data": "another element"}`)
+		request, _ := http.NewRequest("POST", "/push", body)
 		expectedStatus := http.StatusOK
 		expectedContent := models.Response{"push", "another element"}
 
@@ -201,7 +203,8 @@ func TestPush(t *testing.T) {
 	})
 
 	t.Run("Push on Stack with multiple elements", func(t *testing.T) {
-		request, _ := http.NewRequest("POST", "/push/yet another element", nil)
+		body := strings.NewReader(`{"Data": "yet another element"}`)
+		request, _ := http.NewRequest("POST", "/push", body)
 		expectedStatus := http.StatusOK
 		expectedContent := models.Response{"push", "yet another element"}
 


### PR DESCRIPTION
The only operation that accepts parameters is `push`. I've added a struct to handle requests to be handled as JSON bodies instead as path parameters:
```golang
type Request struct {
	Data interface{}
}
```

Changes to the servers include deserialization of the body and removal of the path parameter.