### PR TITLE
persist datastructure in a database

### DIFF
--- a/cmd/teleq/commands_test.go
+++ b/cmd/teleq/commands_test.go
@@ -6,15 +6,20 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/julienschmidt/httprouter"
+	"github.com/riccardomc/teleq/server"
+	"github.com/riccardomc/teleq/stack"
 )
 
 type MockServer struct{}
 
-func (s *MockServer) Size() httprouter.Handle { return nil }
-func (s *MockServer) Peek() httprouter.Handle { return nil }
-func (s *MockServer) Push() httprouter.Handle { return nil }
-func (s *MockServer) Pop() httprouter.Handle  { return nil }
-func (s *MockServer) Serve(port int)          {}
+func (s *MockServer) Size() httprouter.Handle                                  { return nil }
+func (s *MockServer) Peek() httprouter.Handle                                  { return nil }
+func (s *MockServer) Push() httprouter.Handle                                  { return nil }
+func (s *MockServer) Pop() httprouter.Handle                                   { return nil }
+func (s *MockServer) SetPort(int) stackserver.ServerInterface                  { return s }
+func (s *MockServer) SetRouter(*httprouter.Router) stackserver.ServerInterface { return s }
+func (s *MockServer) SetStack(stack.Stack) stackserver.ServerInterface         { return s }
+func (s *MockServer) Serve()                                                   {}
 
 type clientTest struct {
 	operation    string

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,9 @@
 package stackserver
 
-import "github.com/julienschmidt/httprouter"
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/riccardomc/teleq/stack"
+)
 
 //ServerInterface represents a server
 type ServerInterface interface {
@@ -8,5 +11,8 @@ type ServerInterface interface {
 	Peek() httprouter.Handle
 	Push() httprouter.Handle
 	Pop() httprouter.Handle
-	Serve(int)
+	SetPort(int) ServerInterface
+	SetRouter(*httprouter.Router) ServerInterface
+	SetStack(stack.Stack) ServerInterface
+	Serve()
 }

--- a/server/stackserver.go
+++ b/server/stackserver.go
@@ -6,15 +6,18 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/riccardomc/teleq/stack"
+	"github.com/riccardomc/teleq/stack/memory"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/riccardomc/teleq/models"
-	"github.com/riccardomc/teleq/stack"
 )
 
 //StackServer serves a stack through an httprouter
 type StackServer struct {
-	Stack  *stack.Stack
+	Stack  stack.Stack
 	Router *httprouter.Router
+	Port   int
 }
 
 //Size returns the size operation handle of the server
@@ -62,16 +65,38 @@ func (server *StackServer) Pop() httprouter.Handle {
 }
 
 //Serve starts listening and serving
-func (server *StackServer) Serve(port int) {
-	http.ListenAndServe(":"+strconv.Itoa(port), server.Router)
+func (server *StackServer) Serve() {
+	http.ListenAndServe(":"+strconv.Itoa(server.Port), server.Router)
 }
 
 //New gives you a new server, yo
 func New() *StackServer {
-	server := StackServer{stack.New(), httprouter.New()}
+	server := StackServer{
+		memory.New(),
+		httprouter.New(),
+		9009,
+	}
 	server.Router.GET("/peek", server.Peek())
 	server.Router.POST("/push", server.Push())
 	server.Router.GET("/pop", server.Pop())
 	server.Router.GET("/size", server.Size())
 	return &server
+}
+
+//SetPort sets the port of the server will listen now
+func (server *StackServer) SetPort(port int) ServerInterface {
+	server.Port = port
+	return server
+}
+
+//SetStack sets the stack used by the server
+func (server *StackServer) SetStack(stack stack.Stack) ServerInterface {
+	server.Stack = stack
+	return server
+}
+
+//SetRouter sets the router used by the server
+func (server *StackServer) SetRouter(router *httprouter.Router) ServerInterface {
+	server.Router = router
+	return server
 }

--- a/stack/database/database.go
+++ b/stack/database/database.go
@@ -1,0 +1,25 @@
+package database
+
+import "github.com/jinzhu/gorm"
+
+//Database represents a database
+type Database struct {
+	dialect string
+	url     string
+	client  *gorm.DB
+}
+
+//NewDatabase database
+func NewDatabase(dialect, url string) *Database {
+	return &Database{dialect, url, nil}
+}
+
+//Connect to database
+func (db *Database) Connect() error {
+	client, err := gorm.Open(db.dialect, db.url)
+	if err != nil {
+		return err
+	}
+	db.client = client
+	return nil
+}

--- a/stack/database/frame.go
+++ b/stack/database/frame.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"bytes"
+	"encoding/gob"
+
+	"github.com/jinzhu/gorm"
+)
+
+//Frame is a Stack Frame
+type Frame struct {
+	Data interface{}
+}
+
+//PersistentFrame is just a fake object
+type PersistentFrame struct {
+	gorm.Model
+	Stack string
+	Data  []byte
+}
+
+//Serialize a frame into bytes
+func (f *Frame) Serialize() ([]byte, error) {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(f)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+//Deserialize bytes into a Frame
+func (f *Frame) Deserialize(Data []byte) (*Frame, error) {
+	err := gob.NewDecoder(bytes.NewReader(Data)).Decode(f)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/stack/database/frame_test.go
+++ b/stack/database/frame_test.go
@@ -1,0 +1,33 @@
+package database
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFrame(t *testing.T) {
+	t.Run("Serialize", func(t *testing.T) {
+		f := Frame{"this is some data"}
+		expectedSerialized := []byte{28, 255, 129, 3, 1, 1, 5, 70, 114, 97, 109, 101, 1, 255, 130, 0, 1, 1, 1, 4, 68, 97, 116, 97, 1, 16, 0, 0, 0, 32, 255, 130, 1, 6, 115, 116, 114, 105, 110, 103, 12, 19, 0, 17, 116, 104, 105, 115, 32, 105, 115, 32, 115, 111, 109, 101, 32, 100, 97, 116, 97, 0}
+		actualSerialized, err := f.Serialize()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(expectedSerialized, actualSerialized) {
+			t.Error(expectedSerialized, "!=", actualSerialized)
+		}
+	})
+
+	t.Run("Deserialize", func(t *testing.T) {
+		data := []byte{28, 255, 129, 3, 1, 1, 5, 70, 114, 97, 109, 101, 1, 255, 130, 0, 1, 1, 1, 4, 68, 97, 116, 97, 1, 16, 0, 0, 0, 32, 255, 130, 1, 6, 115, 116, 114, 105, 110, 103, 12, 19, 0, 17, 116, 104, 105, 115, 32, 105, 115, 32, 115, 111, 109, 101, 32, 100, 97, 116, 97, 0}
+		expectedDeserialized := Frame{"this is some data"}
+		actualDeserialized := Frame{}
+		_, err := actualDeserialized.Deserialize(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if expectedDeserialized != actualDeserialized {
+			t.Error(expectedDeserialized, "!=", actualDeserialized)
+		}
+	})
+}

--- a/stack/database/stack.go
+++ b/stack/database/stack.go
@@ -1,0 +1,128 @@
+package database
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+
+	_ "github.com/jinzhu/gorm/dialects/postgres" // noqa
+	_ "github.com/jinzhu/gorm/dialects/sqlite"   // noqa
+)
+
+//Stack data structure
+type Stack struct {
+	gorm.Model
+	db     *Database
+	Name   string            `gorm:"type:VARCHAR(100);PRIMARY_KEY"`
+	Frames []PersistentFrame `gorm:"foreignkey:Stack"`
+	mux    sync.Mutex
+}
+
+//New returns a new Stack
+func New() *Stack {
+	return &Stack{
+		Frames: make([]PersistentFrame, 0),
+		Name:   uuid.New().String(),
+	}
+}
+
+func guessDialect(connectionString string) (string, error) {
+	if strings.HasPrefix(connectionString, "/") {
+		return "sqlite3", nil
+	}
+	if strings.Contains(connectionString, "host=") {
+		return "postgres", nil
+	}
+	return "", errors.New("Cannot guess connection SQL dialect")
+}
+
+//Init the Stack
+func (s *Stack) Init(params ...interface{}) error {
+	databaseConnectionString := params[0].(string)
+	dialect, err := guessDialect(databaseConnectionString)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Got a", dialect, "database")
+	s.db = NewDatabase(dialect, databaseConnectionString)
+	err = s.db.Connect()
+	if err != nil {
+		return err
+	}
+	s.db.client.AutoMigrate(&Stack{})
+	s.db.client.AutoMigrate(&PersistentFrame{})
+	s.db.client.Create(s)
+	return nil
+}
+
+//Push a frame on the stack
+func (s *Stack) Push(data interface{}) {
+	frame := Frame{data}
+	serializedFrame, err := frame.Serialize()
+	if err != nil {
+		panic(err)
+	}
+	pf := PersistentFrame{Data: serializedFrame, Stack: s.Name}
+	s.db.client.Create(&pf)
+}
+
+//Peek top frame on the stack
+func (s *Stack) Peek() interface{} {
+	frame := Frame{}
+	persistentFrame := PersistentFrame{}
+	s.db.client.Last(&persistentFrame)
+	frame.Deserialize(persistentFrame.Data)
+	return frame.Data
+}
+
+//Size returns the number of frames in the stack
+func (s *Stack) Size() int {
+	var count int
+	s.db.client.Table("persistent_frames").Select(
+		"persistent_frames.stack").Joins(
+		"left join stacks on stacks.name = persistent_frames.stack").Count(&count)
+	return count
+}
+
+//Pop a persistent frame
+func (s *Stack) Pop() interface{} {
+	frame := Frame{}
+	persistentFrame := &PersistentFrame{}
+
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	t := s.db.client.Begin()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Rollback()
+		}
+	}()
+
+	if t.Error != nil {
+		return nil
+	}
+
+	if err := t.Last(persistentFrame).Error; err != nil {
+		t.Rollback()
+		return nil
+	}
+
+	if persistentFrame != nil {
+		if err := t.Unscoped().Delete(persistentFrame).Error; err != nil {
+			t.Rollback()
+			return nil
+		}
+	}
+
+	if err := t.Commit().Error; err != nil {
+		return nil
+	}
+
+	frame.Deserialize(persistentFrame.Data)
+	return frame.Data
+}

--- a/stack/database/stack_test.go
+++ b/stack/database/stack_test.go
@@ -1,0 +1,73 @@
+package database
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/jinzhu/gorm/dialects/sqlite" //noqa
+)
+
+func TestStack(t *testing.T) {
+
+	stack := New()
+	database := "/tmp/" + uuid.New().String()
+	defer func() {
+		exec.Command("rm", "-f", database).Run()
+	}()
+
+	t.Run("Init", func(t *testing.T) {
+		err := stack.Init(database)
+		if err != nil {
+			t.Error(err)
+		}
+		for _, table := range []string{"stacks", "persistent_frames"} {
+			if !stack.db.client.HasTable(table) {
+				t.Error("Table", table, "not initialized")
+			}
+		}
+	})
+
+	t.Run("Size", func(t *testing.T) {
+		stack.Push("this")
+		size := stack.Size()
+		if !(size > 0) {
+			t.Error(size, "!> 0")
+		}
+	})
+
+	t.Run("Push", func(t *testing.T) {
+		expectedSize := stack.Size() + 1
+		stack.Push("something")
+		actualSize := stack.Size()
+		if expectedSize != actualSize {
+			t.Error(actualSize, "!=", expectedSize)
+		}
+	})
+
+	t.Run("Peek", func(t *testing.T) {
+		expectedData := "a value"
+		stack.Push(expectedData)
+		actualData := stack.Peek()
+		if actualData != expectedData {
+			t.Error(actualData, "!=", expectedData)
+		}
+	})
+
+	t.Run("Pop", func(t *testing.T) {
+		expectedSize := stack.Size()
+		expectedData := "this value"
+		stack.Push(expectedData)
+
+		actualData := stack.Pop()
+		actualSize := stack.Size()
+
+		if actualData != expectedData {
+			t.Error(actualData, "!=", expectedData)
+		}
+
+		if actualSize != expectedSize {
+			t.Error(actualSize, "!=", expectedSize)
+		}
+	})
+}

--- a/stack/memory/stack.go
+++ b/stack/memory/stack.go
@@ -1,0 +1,50 @@
+package memory
+
+//Stack data structure
+type Stack struct {
+	frames []Frame
+}
+
+//Frame is a stack frame
+type Frame struct {
+	Data interface{}
+}
+
+//New returns a new stack
+func New() *Stack {
+	return &Stack{make([]Frame, 0)}
+}
+
+//Init initializes the stack
+func (s *Stack) Init(parameters ...interface{}) error {
+	s.frames = make([]Frame, 0)
+	return nil
+}
+
+//Size returns the number of elements in the stack
+func (s *Stack) Size() int {
+	return len(s.frames)
+}
+
+//Push an element in the stack
+func (s *Stack) Push(data interface{}) {
+	s.frames = append(s.frames, Frame{data})
+}
+
+//Peek returns the element at the top of the stack
+func (s *Stack) Peek() interface{} {
+	if s.Size() == 0 {
+		return nil
+	}
+
+	return s.frames[s.Size()-1].Data
+}
+
+//Pop returns and removes the element at the top of the stack
+func (s *Stack) Pop() interface{} {
+	data := s.Peek()
+	if data != nil {
+		s.frames = s.frames[:s.Size()-1]
+	}
+	return data
+}

--- a/stack/memory/stack_test.go
+++ b/stack/memory/stack_test.go
@@ -1,4 +1,4 @@
-package stack
+package memory
 
 import "testing"
 

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -1,44 +1,10 @@
 package stack
 
-//Frame is a stack frame
-type Frame struct {
-	data interface{}
-}
-
-//Stack data structure
-type Stack struct {
-	frames []Frame
-}
-
-//New returns a new stack
-func New() *Stack {
-	return &Stack{make([]Frame, 0)}
-}
-
-//Size returns the number of elements in the stack
-func (s *Stack) Size() int {
-	return len(s.frames)
-}
-
-//Push an element in the stack
-func (s *Stack) Push(data interface{}) {
-	s.frames = append(s.frames, Frame{data})
-}
-
-//Peek returns the element at the top of the stack
-func (s *Stack) Peek() interface{} {
-	if s.Size() == 0 {
-		return nil
-	}
-
-	return s.frames[s.Size()-1].data
-}
-
-//Pop returns and removes the element at the top of the stack
-func (s *Stack) Pop() interface{} {
-	data := s.Peek()
-	if data != nil {
-		s.frames = s.frames[:s.Size()-1]
-	}
-	return data
+// Stack defines the interface of a Stack data structure
+type Stack interface {
+	Size() int
+	Push(interface{})
+	Peek() interface{}
+	Pop() interface{}
+	Init(...interface{}) error
 }


### PR DESCRIPTION
I needed to refactor part of the code to keep the in memory implementation working and add the database one. Stack is now an `interface`:
```golang
// Stack defines the interface of a Stack data structure
type Stack interface {
       Size() int
       Push(interface{})
       Peek() interface{}
       Pop() interface{}
       Init(...interface{}) error
 }
```

And I've introduced a `ServerInterface` with a couple of methods to control the configuration and behaviour:
```golang
//ServerInterface represents a server
type ServerInterface interface {
	Size() httprouter.Handle
	Peek() httprouter.Handle
	Push() httprouter.Handle
	Pop() httprouter.Handle
	SetPort(int) ServerInterface
	SetRouter(*httprouter.Router) ServerInterface
	SetStack(stack.Stack) ServerInterface
	Serve()
}
```
This allows me to chose which stack to use based on CLI flags or environment variables:
```golang
TELEQ_DATABASE_HOST="host=localhost port=5432 user=postgres dbname=postgres password=mysecretpassword sslmode=disable" ./teleq server
```

I've used [gorm](http://gorm.io/) to talk to the database.
```golang
//PersistentFrame is just a fake object
type PersistentFrame struct {
	gorm.Model
	Stack string
	Data  []byte
}
```
```golang
//Stack data structure
type Stack struct {
       gorm.Model
       db     *Database
       Name   string            `gorm:"type:VARCHAR(100);PRIMARY_KEY"`
       Frames []PersistentFrame `gorm:"foreignkey:Stack"`
       mux    sync.Mutex
}
```

Data in the database is ultimately storead as `[]byte` and encoded using [gob](https://golang.org/pkg/encoding/gob/) so I can keep using `interface{}` as input data type and restore the content correctly when outputting it without implementing magical serialization mechanisms.